### PR TITLE
 heroku上でwebsocketが使えるようにする 

### DIFF
--- a/web/channels/oekaki_socket.ex
+++ b/web/channels/oekaki_socket.ex
@@ -4,7 +4,7 @@ defmodule OekakiDengonGame.OekakiSocket do
   channel "lobby", OekakiDengonGame.LobbyChannel
   channel "room:*", OekakiDengonGame.RoomChannel
 
-  transport :websocket, Phoenix.Transports.WebSocket
+  transport :websocket, Phoenix.Transports.WebSocket, check_origin: false
 
   def connect(_params, socket) do
     {:ok, socket}


### PR DESCRIPTION
以下のようなエラーが出ていた

```
09:00:06.959 [error] Could not check origin for Phoenix.Socket transport.

This happens when you are attempting a socket connection to
a different host than the one configured in your config/
files. For example, in development the host is configured
to "localhost" but you may be trying to access it from
"127.0.0.1". To fix this issue, you may either:

  1. update [url: [host: ...]] to your actual host in the
     config file for your current environment (recommended)

  2. pass the :check_origin option when configuring your
     endpoint or when configuring the transport in your
     UserSocket module, explicitly outlining which origins
     are allowed:

        check_origin: ["https://example.com",
                       "//another.com:888", "//other.com"]
```

どうやらwebsocketで接続する際にoriginのチェックをしているらしい。
ここは一旦originチェックを外して動作を確認する
